### PR TITLE
Cenários user bloqueado

### DIFF
--- a/src/main/java/org/example/PageObjects/Celular.java
+++ b/src/main/java/org/example/PageObjects/Celular.java
@@ -1,0 +1,14 @@
+package org.example.PageObjects;
+
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.remote.AndroidMobileCapabilityType;
+
+public class Celular {
+    private static String appId;
+
+    public static void resetApp(AppiumDriver driver){
+        appId = (String) driver.getCapabilities().getCapability(AndroidMobileCapabilityType.APP_PACKAGE);
+        driver.terminateApp(appId);
+        driver.activateApp(appId);
+    }
+}

--- a/src/main/java/org/example/PageObjects/EsqueciMinhaSenha.java
+++ b/src/main/java/org/example/PageObjects/EsqueciMinhaSenha.java
@@ -13,6 +13,7 @@ public class EsqueciMinhaSenha {
     private MobileElement inputCPFUsuario;
     private MobileElement botaoConfirmar;
     private MobileElement msgCPFInvalido;
+    private MobileElement botaoCancelar;
 
 
     public EsqueciMinhaSenha(AppiumDriver driver) {
@@ -26,6 +27,7 @@ public class EsqueciMinhaSenha {
 
         inputCPFUsuario = (MobileElement) driver.findElementByXPath("//android.widget.EditText[@content-desc=\"Digite o seu cpf para recuperar a senha\"]");
         botaoConfirmar = (MobileElement) driver.findElementByXPath("//android.view.ViewGroup[@content-desc=\"Botão para confirmar o cpf\"]/android.view.ViewGroup");
+        botaoCancelar = (MobileElement) driver.findElementByXPath("//android.view.ViewGroup[@content-desc=\"Botão para cancelar a recuperação de senha\"]");
     }
 
     public void preencherInputCpf(String cpf) {
@@ -34,6 +36,10 @@ public class EsqueciMinhaSenha {
 
     public void clicarBotaoConfirmar(){
         botaoConfirmar.click();
+    }
+
+    public void clicarBotaoCancelar(){
+        botaoCancelar.click();
     }
 
     public void  buscarMensagemContaBloqueada(){

--- a/src/main/java/org/example/PageObjects/Login.java
+++ b/src/main/java/org/example/PageObjects/Login.java
@@ -1,8 +1,10 @@
 package org.example.PageObjects;
 
+import com.google.common.collect.ImmutableMap;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.MobileElement;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
@@ -14,6 +16,7 @@ public class Login {
     private MobileElement textoModalContaBloqueada;
     private MobileElement linkEsqueciMinhaSenha;
     private MobileElement botaoFecharModalErroCPFSenha;
+    private MobileElement iconeInformativo;
 
     private MobileElement modalErro;
 
@@ -68,6 +71,24 @@ public class Login {
         espera.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//*[contains(@text, 'sua conta foi bloqueada temporariamente.')]")));
 
         textoModalContaBloqueada = (MobileElement) driver.findElementByXPath("//*[contains(@text, 'sua conta foi bloqueada temporariamente.')]");
+    }
+
+    public void arrastarModalContaBloqueadaBaixo(){
+        WebDriverWait espera = new WebDriverWait(driver, 10);
+        espera.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//android.widget.FrameLayout[@resource-id=\"android:id/content\"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[1]")));
+
+        iconeInformativo = (MobileElement) driver.findElementByXPath("//android.widget.FrameLayout[@resource-id=\"android:id/content\"]/android.widget.FrameLayout/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[2]/android.view.ViewGroup/android.view.ViewGroup/android.view.ViewGroup[1]");
+        buscarMensagemContaBloqueada();
+
+        Dimension tamanhoTela = driver.manage().window().getSize();
+        int alturaTela = tamanhoTela.getHeight();
+        int alturaModal = alturaTela * 2 / 3;
+        int larguraModal = tamanhoTela.getWidth() / 2;
+
+        driver.executeScript("mobile: flingGesture", ImmutableMap.of("elementId", textoModalContaBloqueada.getId(),
+                "percentage", 100,
+                "direction", "down",
+                "speed", 500));
     }
 
     public void buscarBotaoFecharModalCPFSenha(){

--- a/src/test/java/org/example/DefinicaoPassosCucumber.java
+++ b/src/test/java/org/example/DefinicaoPassosCucumber.java
@@ -1,6 +1,10 @@
 package org.example;
 
+import com.google.common.collect.ImmutableMap;
 import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.android.Activity;
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.remote.AndroidMobileCapabilityType;
 import io.cucumber.java.*;
 import io.cucumber.java.pt.*;
 import org.example.PageObjects.*;
@@ -155,5 +159,21 @@ public class DefinicaoPassosCucumber {
         EsqueciMinhaSenha telaEsqueciminhaSenha = new EsqueciMinhaSenha(driver);
         telaEsqueciminhaSenha.buscarMensagemCPFInvalido();
         Assert.assertTrue(telaEsqueciminhaSenha.getMsgCPFInvalido().isDisplayed());
+
+    }
+
+    @E("reseto o app")
+    public void resetoOApp() {
+        AppiumDriver driver = AppiumDriverConfig.Instance().driver;
+        Celular.resetApp(driver);
+    }
+
+    @E("clico em cancelar")
+    public void clicoEmCancelar() throws InterruptedException {
+        AppiumDriver driver = AppiumDriverConfig.Instance().driver;
+        EsqueciMinhaSenha telaEsqueciminhaSenha = new EsqueciMinhaSenha(driver);
+
+        telaEsqueciminhaSenha.buscarElementos();
+        telaEsqueciminhaSenha.clicarBotaoCancelar();
     }
 }

--- a/src/test/java/org/example/DefinicaoPassosCucumber.java
+++ b/src/test/java/org/example/DefinicaoPassosCucumber.java
@@ -32,6 +32,7 @@ public class DefinicaoPassosCucumber {
         Login telaLogin = new Login(driver);
 
         telaLogin.buscarElementos();
+        telaLogin.limparCamposLogin();
         telaLogin.preencherFormulario("327.721.478-86", "SenhaIncorreta");
         telaLogin.logar();
     }
@@ -56,6 +57,7 @@ public class DefinicaoPassosCucumber {
 
 
         telaLogin.buscarElementos();
+        telaLogin.limparCamposLogin();
         telaLogin.preencherFormulario("327.721.478-86", "Devires@123");
         telaLogin.logar();
     }
@@ -85,4 +87,73 @@ public class DefinicaoPassosCucumber {
             byte[] fileContent = FileUtils.readFileToByteArray(screenshot);
             scenario.attach(fileContent, "image/png", "image1");
         }}
+
+    @Quando("submeto minhas credenciais bloqueadas para login")
+    public void submetoMinhasCredenciaisBloqueadasParaLogin() throws InterruptedException {
+        AppiumDriver driver = AppiumDriverConfig.Instance().driver;
+        Login telaLogin = new Login(driver);
+
+
+        telaLogin.buscarElementos();
+        telaLogin.limparCamposLogin();
+        telaLogin.preencherFormulario("73040542559", "Devires@123");
+        telaLogin.logar();
+    }
+
+
+    @Entao("visualizo o modal de usuário bloqueado")
+    public void visualizoOModalDeUsuárioBloqueado() {
+        AppiumDriver driver = AppiumDriverConfig.Instance().driver;
+        Login telaLogin = new Login(driver);
+
+        telaLogin.buscarMensagemContaBloqueada();
+        Assert.assertTrue(telaLogin.getTextoModalContaBloqueada().isDisplayed());
+    }
+
+    @Dado("que acesso a opção esqueci minha senha na área não logada")
+    public void queAcessoAOpçãoEsqueciMinhaSenhaNaÁreaNãoLogada() throws InterruptedException {
+        AppiumDriver driver = AppiumDriverConfig.Instance().driver;
+        Login telaLogin = new Login(driver);
+
+        telaLogin.buscarElementos();
+        telaLogin.limparCamposLogin();
+        telaLogin.clicarEsqueciMinhaSenha();
+    }
+
+    @Quando("informo um CPF bloqueado")
+    public void informoUmCPFBloqueado() throws InterruptedException {
+        AppiumDriver driver = AppiumDriverConfig.Instance().driver;
+        EsqueciMinhaSenha telaEsqueciSenha = new EsqueciMinhaSenha(driver);
+        telaEsqueciSenha.buscarElementos();
+
+        telaEsqueciSenha.preencherInputCpf("73040542559");
+        telaEsqueciSenha.clicarBotaoConfirmar();
+    }
+
+    @Entao("visualizo o modal de usuário bloqueado na tela de esqueci minha senha")
+    public void visualizoOModalDeUsuárioBloqueadoNaTelaDeEsqueciMinhaSenha() {
+        AppiumDriver driver = AppiumDriverConfig.Instance().driver;
+        EsqueciMinhaSenha telaEsqueciSenha = new EsqueciMinhaSenha(driver);
+
+        telaEsqueciSenha.buscarMensagemContaBloqueada();
+        Assert.assertTrue(telaEsqueciSenha.getTextoModalContaBloqueada().isDisplayed());
+    }
+
+    @Quando("informo um CPF inválido")
+    public void informoUmCPFInválido() throws InterruptedException {
+        AppiumDriver driver = AppiumDriverConfig.Instance().driver;
+        EsqueciMinhaSenha telaEsqueciminhaSenha = new EsqueciMinhaSenha(driver);
+        telaEsqueciminhaSenha.buscarElementos();
+        telaEsqueciminhaSenha.preencherInputCpf("12345678910");
+        telaEsqueciminhaSenha.clicarBotaoConfirmar();
+    }
+
+
+    @Entao("visualizo a mensagem de Documento inválido")
+    public void visualizoAMensagemDeDocumentoInválido() {
+        AppiumDriver driver = AppiumDriverConfig.Instance().driver;
+        EsqueciMinhaSenha telaEsqueciminhaSenha = new EsqueciMinhaSenha(driver);
+        telaEsqueciminhaSenha.buscarMensagemCPFInvalido();
+        Assert.assertTrue(telaEsqueciminhaSenha.getMsgCPFInvalido().isDisplayed());
+    }
 }

--- a/src/test/resources/features/Login.feature
+++ b/src/test/resources/features/Login.feature
@@ -1,12 +1,27 @@
 # language: pt
 Funcionalidade: : Login
 
-  Cenario: Login com credenciais inválidas
+  Cenario: 02 - Login com credenciais inválidas
     Dado que estou na área não logada do app
     Quando submeto minhas credenciais inválidas para login
     Entao visualizo o modal de CPF e, ou Senha inválidos
 
-  Cenario: Login com as credenciais validas
+  Cenario: 03 - login com usuario bloqueado
+    Dado que estou na área não logada do app
+    Quando submeto minhas credenciais bloqueadas para login
+    Entao visualizo o modal de usuário bloqueado
+
+  Cenario: 09 - Recuperação de senha com CPF bloqueado
+    Dado que acesso a opção esqueci minha senha na área não logada
+    Quando informo um CPF bloqueado
+    Entao visualizo o modal de usuário bloqueado na tela de esqueci minha senha
+
+  Cenario: 08 - Recuperação de senha com CPF inválido
+    Dado que acesso a opção esqueci minha senha na área não logada
+    Quando informo um CPF inválido
+    Entao visualizo a mensagem de Documento inválido
+
+  Cenario: 01 - Login com as credenciais validas
     Dado que estou na área não logada do app
     Quando submeto minhas credenciais válidas para login
     Entao acesso a home do aplicativo

--- a/src/test/resources/features/Login.feature
+++ b/src/test/resources/features/Login.feature
@@ -10,16 +10,19 @@ Funcionalidade: : Login
     Dado que estou na área não logada do app
     Quando submeto minhas credenciais bloqueadas para login
     Entao visualizo o modal de usuário bloqueado
+    E reseto o app
 
   Cenario: 09 - Recuperação de senha com CPF bloqueado
     Dado que acesso a opção esqueci minha senha na área não logada
     Quando informo um CPF bloqueado
     Entao visualizo o modal de usuário bloqueado na tela de esqueci minha senha
+    E reseto o app
 
   Cenario: 08 - Recuperação de senha com CPF inválido
     Dado que acesso a opção esqueci minha senha na área não logada
     Quando informo um CPF inválido
     Entao visualizo a mensagem de Documento inválido
+    E clico em cancelar
 
   Cenario: 01 - Login com as credenciais validas
     Dado que estou na área não logada do app


### PR DESCRIPTION
Corrigi o problema onde o teste de usuario bloqueado não fechava o modal, agora ao finalizar a asserção que o modal está na tela o app irá fechar e abrir de novo, garantindo que esteja na página inicial e que os testes subsequentes sejam executados